### PR TITLE
Pin GitHub Actions to full-length commit SHAs

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -20,19 +20,19 @@ jobs:
       matrix:
         provider: [capa, capg, caph, capz, capk]
     steps:
-      - uses: actions/checkout@v1
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
 
       - name: Set up QEMU
         id: qemu
-        uses: docker/setup-qemu-action@v3
+        uses: docker/setup-qemu-action@29109295f81e9208d7d86ff1c6c12d2833863392 # v3.6.0
         with:
           cache-image: false
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@e468171a9de216ec08956ac3ada2f0791b6bd435 # v3.11.1
 
       - name: Log in to the GitHub Container registry
-        uses: docker/login-action@v2
+        uses: docker/login-action@74a5d142397b4f367a81961eba4e8cd7edddf772 # v3.4.0
         with:
           registry: ghcr.io
           username: 1gtm


### PR DESCRIPTION
The Release workflow was failing because the org policy requires all actions to be pinned to a full-length commit SHA:

```
The actions actions/checkout@v1, docker/setup-qemu-action@v1, docker/setup-buildx-action@v1, and docker/login-action@v2 are not allowed in kluster-api/capi-deployer because all actions must be pinned to a full-length commit SHA.
```

Pin all four actions in `release.yml` and bump them to current stable versions:

| Action | Was | Now |
|---|---|---|
| `actions/checkout` | `@v1` | v4.2.2 |
| `docker/setup-qemu-action` | `@v1` | v3.6.0 |
| `docker/setup-buildx-action` | `@v1` | v3.11.1 |
| `docker/login-action` | `@v2` | v3.4.0 |