### PR TITLE
Pin GitHub Actions to full-length commit SHAs

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -20,17 +20,17 @@ jobs:
       matrix:
         provider: [capa, capg, caph, capz, capk]
     steps:
-      - uses: actions/checkout@v1
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
 
       - name: Set up QEMU
         id: qemu
-        uses: docker/setup-qemu-action@v1
+        uses: docker/setup-qemu-action@c7c53464625b32c7a7e944ae62b3e17d2b600130 # v3.7.0
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v1
+        uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3.12.0
 
       - name: Log in to the GitHub Container registry
-        uses: docker/login-action@v2
+        uses: docker/login-action@4907a6ddec9925e35a0a9e82d7399ccc52663121 # v4.1.0
         with:
           registry: ghcr.io
           username: 1gtm


### PR DESCRIPTION
The Release workflow fails org policy because actions must be pinned to a full-length commit SHA.

Pin all four actions in `release.yml` to SHAs (matching the versions already used on `release-1.30`):

| Action | Version |
|---|---|
| `actions/checkout` | v4.3.1 |
| `docker/setup-qemu-action` | v3.7.0 |
| `docker/setup-buildx-action` | v3.12.0 |
| `docker/login-action` | v4.1.0 |